### PR TITLE
Fixes for GNOME Shell 42

### DIFF
--- a/cmus-status@yagreg7.gmail.com/metadata.json
+++ b/cmus-status@yagreg7.gmail.com/metadata.json
@@ -1,10 +1,10 @@
 {
 	"shell-version": [
-		"40", "41"
+		"40", "41", "42"
 	], 
 	"name": "cmus status", 
 	"description": "Shows cmus status", 
-	"version": "10",
+	"version": "11",
 	"uuid": "cmus-status@yagreg7.gmail.com",
 	"url": "https://github.com/GregTheMadMonk/gnome-cmus-status",
 	"settings-schema": "org.gnome.shell.extensions.cmus-status.gschema.xml"

--- a/cmus-status@yagreg7.gmail.com/shared.js
+++ b/cmus-status@yagreg7.gmail.com/shared.js
@@ -4,22 +4,22 @@ const Extension 	= ExtensionUtils.getCurrentExtension();
 const Gio		= imports.gi.Gio;
 const GioSSS		= Gio.SettingsSchemaSource;
 
-const settingsSchema = "org.gnome.shell.extensions.cmus-status";
-const needsUpdateKey = "settings-updated";
-const updateIntervalKey = "update-interval";
-const enableBindsKey = "enable-binds";
-const enableNotKey = "enable-notifications";
-const simpleTrayKey = "simple-tray";
-const notPosXKey = "notification-posx";
-const notPosYKey = "notification-posy";
-const notFadeStartKey = "notification-fade-start-time";
-const notFadeDurationKey = "notification-fade-duration";
-const trayFormatKey = "tray-format";
-const notFormatKey = "notification-format";
+var settingsSchema = "org.gnome.shell.extensions.cmus-status";
+var needsUpdateKey = "settings-updated";
+var updateIntervalKey = "update-interval";
+var enableBindsKey = "enable-binds";
+var enableNotKey = "enable-notifications";
+var simpleTrayKey = "simple-tray";
+var notPosXKey = "notification-posx";
+var notPosYKey = "notification-posy";
+var notFadeStartKey = "notification-fade-start-time";
+var notFadeDurationKey = "notification-fade-duration";
+var trayFormatKey = "tray-format";
+var notFormatKey = "notification-format";
 
-const playBindKey = "play-bind";
-const prevBindKey = "prev-bind";
-const nextBindKey = "next-bind";
+var playBindKey = "play-bind";
+var prevBindKey = "prev-bind";
+var nextBindKey = "next-bind";
 
 // converts bind ID from settings to accelerator
 function bindIdToAccel(bindId)


### PR DESCRIPTION
The JS engine in GNOME Shell 42 seems to be strict about not allowing const's to be exported from a file. Had to update the names exported from shared.js to extension.js to var.

Also bumped the version and compatibility settings in metadata.json. 